### PR TITLE
Flex-wrap com quebra de linha

### DIFF
--- a/src/renderers/p.js
+++ b/src/renderers/p.js
@@ -5,10 +5,11 @@ export default class RenderP extends Component {
     render() {
         return (
             <View style={{
-                flexDirection: 'row', 
+                flexDirection: 'row',
                 flexWrap: 'wrap',
                 width: '100%',
-                marginVertical: 5
+                marginVertical: 5,
+                padding: 0
             }}>
                 {this.props.element.children.map(
                     (e, i) => this.props.renderComponent(e, i, {


### PR DESCRIPTION
Quando usado, dependendo do tamanho da ultima palavra, ele adicionava espaços a mais com margem superior negativa por conta da ausência de padding.