### PR TITLE
Fix:  Wrap quebra quando o texto é longo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-htmlviewer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "HTML to native component.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-htmlviewer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "HTML to native component.",
   "main": "index.js",
   "repository": {

--- a/src/HTMLViewer.js
+++ b/src/HTMLViewer.js
@@ -15,8 +15,8 @@ export default class HTMLViewer extends Component {
             customProps: props.customProps || {},
             renderers: {
                 default: require('./renderers/default'),
-                p: require('./renderers/p'),
                 img: require('./renderers/img'),
+                p: require('./renderers/p'),
                 b: require('./renderers/b'),
                 strong: require('./renderers/strong'),
                 i: require('./renderers/i'),
@@ -43,7 +43,7 @@ export default class HTMLViewer extends Component {
             let el = dom.map((e, i) => this.renderComponent(e, i));
             this.setState({ el });
         });
-        
+
         const parser = new htmlparser.Parser(handler);
         parser.write(this.props.html);
         parser.done();
@@ -54,15 +54,16 @@ export default class HTMLViewer extends Component {
             ...this.state.renderers,
             ...this.state.customRenderers
         };
-        
+
         let { customProps } = this.state;
 
+        console.log(e.type)
         switch (e.type) {
             case 'tag':
                 const Comp = (renderers[e.name] || renderers["default"]).default;
-                
+
                 return (
-                    <Comp 
+                    <Comp
                         key={i}
                         renderComponent={this.renderComponent}
                         element={e}
@@ -70,19 +71,21 @@ export default class HTMLViewer extends Component {
                         {...(customProps[e.name] || customProps["default"])}
                     />
                 );
-            
+
             case 'text':
                 return entities.decodeHTML(e.data).split(' ').map((text, j) => (
-                    <Text key={`${i}_${j}`} style={[{marginRight: 3}, style]}>
-                        {text}
-                    </Text>
+                    <View>
+                        <Text key={`${i}_${j}`} style={[{ marginRight: 3, margin: 0 }, style]}>
+                            {text}
+                        </Text>
+                    </View>
                 ));
         }
     };
 
     render() {
         return (
-            <View style={{flexDirection: 'row', flexWrap: 'wrap'}}>
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
                 {this.state.el}
             </View>
         );

--- a/src/HTMLViewer.js
+++ b/src/HTMLViewer.js
@@ -51,13 +51,13 @@ export default class HTMLViewer extends Component {
 
     renderComponent = (e, i, style = {}) => {
         let renderers = {
+            
             ...this.state.renderers,
             ...this.state.customRenderers
         };
 
         let { customProps } = this.state;
 
-        console.log(e.type)
         switch (e.type) {
             case 'tag':
                 const Comp = (renderers[e.name] || renderers["default"]).default;

--- a/src/renderers/br.js
+++ b/src/renderers/br.js
@@ -5,10 +5,11 @@ export default class RenderBr extends Component {
     render() {
         return (
             <View style={{
-                flexDirection: 'row', 
+                flexDirection: 'row',
                 flexWrap: 'wrap',
                 width: '100%',
-                height: 10
+                height: '10%',
+                padding: 0
             }}></View>
         );
     }

--- a/src/renderers/default.js
+++ b/src/renderers/default.js
@@ -4,7 +4,7 @@ import { View } from 'react-native';
 export default class RenderDefault extends Component {
     render() {
         return (
-            <View style={{flexDirection: 'row', flexWrap: 'wrap'}}>
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
                 {this.props.element.children.map(
                     (e, i) => this.props.renderComponent(e, i, {
                         ...this.props.style

--- a/src/renderers/p.js
+++ b/src/renderers/p.js
@@ -5,16 +5,17 @@ export default class RenderP extends Component {
     render() {
         return (
             <View style={{
-                flexDirection: 'row', 
+                flexDirection: 'row',
                 flexWrap: 'wrap',
                 width: '100%',
-                marginVertical: 5
             }}>
-                {this.props.element.children.map(
-                    (e, i) => this.props.renderComponent(e, i, {
-                        ...this.props.style
-                    })
-                )}
+                <>
+                    {this.props.element.children.map(
+                        (e, i) => this.props.renderComponent(e, i, {
+                            ...this.props.style
+                        })
+                    )}
+                </>
             </View>
         );
     }


### PR DESCRIPTION
Em alguns dispositivos quando a string dentro da tag "<p/>" é longa, ela passa o espaçamento ignorando o wrap.