### PR TITLE
Update br.js

### DIFF
--- a/src/renderers/br.js
+++ b/src/renderers/br.js
@@ -8,7 +8,6 @@ export default class RenderBr extends Component {
                 flexDirection: 'row',
                 flexWrap: 'wrap',
                 width: '100%',
-                height: '10%',
                 padding: 0
             }}></View>
         );


### PR DESCRIPTION
Remover altura pre-definida.

Em alguns dispositivos pode causar 'quebra' de texto e sobreposição.